### PR TITLE
Add README note that ffmpeg v7 is incompatible with the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ and does not intend to provide compatibility for older clients.
 
 ### Prerequisites
 
--   [ffmpeg](https://www.ffmpeg.org/download.html)
+-   [ffmpeg](https://www.ffmpeg.org/download.html)[^2] (v6 or lower)
 -   [Node.js](https://nodejs.org)
 -   [Yarn 1](https://classic.yarnpkg.com/en/docs/install) (not 2, we haven't migrated yet)
 -   [Java](https://www.oracle.com/java/technologies/downloads/) (or [OpenJDK](https://openjdk.org/)) to run the texture packer
 -   [cURL](https://curl.se/download.html)[^1] to download the texture packer
 
 [^1]: cURL is already installed on most Windows, Linux and macOS systems.
+[^2]: ffmpeg v7 is known to be incompatible with this project. Dependency `gulp-fluent-ffmpeg` cannot create MP3 files with ffmpeg v7, but it can create them with ffmpeg v6.
 
 ### Development
 


### PR DESCRIPTION
I built Shapez Community Edition from source today on MacOS M1 with ARM processor. I was able to successfully build the project.

I did have to resolve an error with FFmpeg, so I wanted to share the resolution.

```
[15:23:32] Plumber found unhandled error:
 Error: Output format mp3 is not available
...
[15:23:42] The following tasks did not complete: package.standalone-steam.darwin-arm64, <series>, 
  <series>, <parallel>, <series>, <series>, <parallel>, musicHQ, <series>, sfxOptimize
```

I stumbled on the solution on [StackOverflow](https://stackoverflow.com/questions/78451838/fluent-ffmpeg-error-with-mp3-output-format-when-streaming-audio-in-node-js). There are details there on whether/how the issue will be fixed upstream.

Basically, FFmpeg v7 is incompatible with the project's dependencies. This projects dependency `gulp-fluent-ffmpeg` itself depends on `fluent-ffmpeg`, which appears to be  [incompatible with FFmpeg v7](https://github.com/fluent-ffmpeg/node-fluent-ffmpeg/issues/1266).

**Solution: use FFmpeg v6 to build Shapez Community Edition.**