### PR TITLE
Fix and modify ESLint configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,9 +41,8 @@ const runtimeConfig = tseslint.config(...baseConfig, {
         },
     },
     rules: {
-        // Mostly caused by JSDoc imports, so don't annoy with errors but keep
-        // a reminder!
-        "@typescript-eslint/no-unused-vars": "warn",
+        // Mostly caused by JSDoc imports, disable for now
+        "@typescript-eslint/no-unused-vars": "off",
         // FIXME: enforce when we're ready to
         "prefer-const": "warn",
     },
@@ -56,11 +55,11 @@ export default [
     },
     ...nodeConfig.map(config => ({
         ...config,
-        files: ["*.(ts|js)", "(gulp|electron)/**/*.(ts|js)"],
+        files: ["*.{ts,js}", "{gulp,electron}/**/*.{ts,js}"],
         ignores: ["gulp/preloader/*.js"],
     })),
     ...runtimeConfig.map(config => ({
         ...config,
-        files: ["src/**/*.(ts|js)x?"],
+        files: ["src/**/*.{ts,js,tsx,jsx}"],
     })),
 ];

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "module",
     "scripts": {
         "gulp": "gulp --cwd gulp",
-        "lint": "(eslint . && tsc && tsc -p src) || (tsc && tsc -p src) || tsc -p src",
+        "lint": "eslint .",
         "prettier-all": "prettier --write src/**/*.* && prettier --write gulp/**/*.*",
         "buildTypes": "tsc src/js/application.js --declaration --allowJs --emitDeclarationOnly --skipLibCheck --out types.js",
         "package-win32-x64": "gulp --cwd gulp package.standalone-steam.win32-x64",


### PR DESCRIPTION
As mentioned in https://github.com/tobspr-games/shapez-community-edition/pull/30#pullrequestreview-2127124280, the simplified minimatch patterns were wrong. This PR fixes these and along with that disables the `@typescript-eslint/no-unused-vars` rule entirely for `src/`. I also removed `tsc` calls from the `lint` script because they are mostly duplicating ESLint checks while the codebase stays mostly JS.