### PR TITLE
Replace some outside usages of HubGoals#storedShapes

### DIFF
--- a/src/js/game/hud/parts/statistics_handle.js
+++ b/src/js/game/hud/parts/statistics_handle.js
@@ -1,6 +1,6 @@
 import { makeOffscreenBuffer } from "../../../core/buffer_utils";
 import { globalConfig } from "../../../core/config";
-import { clamp, formatBigNumber, round2Digits } from "../../../core/utils";
+import { clamp, formatBigNumber } from "../../../core/utils";
 import { T } from "../../../translations";
 import { enumAnalyticsDataSource } from "../../production_analytics";
 import { GameRoot } from "../../root";
@@ -92,9 +92,7 @@ export class HUDShapeStatisticsHandle {
 
         switch (dataSource) {
             case enumAnalyticsDataSource.stored: {
-                this.counter.innerText = formatBigNumber(
-                    this.root.hubGoals.storedShapes[this.definition.getHash()] || 0
-                );
+                this.counter.innerText = formatBigNumber(this.root.hubGoals.getShapesStored(this.definition));
                 break;
             }
             case enumAnalyticsDataSource.delivered:

--- a/src/js/platform/achievement_provider.js
+++ b/src/js/platform/achievement_provider.js
@@ -5,10 +5,10 @@ import { GameRoot } from "../game/root";
 import { THEMES } from "../game/theme";
 /* typehints:end */
 
+import { globalConfig } from "../core/config";
+import { ShapeItem } from "../game/items/shape_item";
 import { enumAnalyticsDataSource } from "../game/production_analytics";
 import { ShapeDefinition } from "../game/shape_definition";
-import { ShapeItem } from "../game/items/shape_item";
-import { globalConfig } from "../core/config";
 
 export const ACHIEVEMENTS = {
     belt500Tiles: "belt500Tiles",
@@ -423,7 +423,8 @@ export class AchievementCollection {
         return {
             init: ({ key }) => this.unlock(key, ShapeDefinition.fromShortKey(SHAPE_BP)),
             isValid: definition =>
-                definition.cachedHash === SHAPE_BP && this.root.hubGoals.storedShapes[SHAPE_BP] >= count,
+                definition.cachedHash === SHAPE_BP &&
+                this.root.hubGoals.getShapesStoredByKey(SHAPE_BP) >= count,
             signal: "shapeDelivered",
         };
     }


### PR DESCRIPTION
Only 2 usages were changed. Most of them are inside of the HubGoals class, perhaps for performance reasons. These will stay, at least for now. Regardless, this change makes it easier to refactor HubGoals as long as the getShapesStored(ByKey) interface is respected.