### PR TITLE
Fix runnable-textpacker.jar download

### DIFF
--- a/gulp/image-resources.js
+++ b/gulp/image-resources.js
@@ -94,7 +94,7 @@ export async function buildAtlas() {
             const escapedLink = JSON.stringify(runnableTPSource);
 
             try {
-                execute(`curl -o runnable-texturepacker.jar ${escapedLink}`);
+                await execute(`curl -o runnable-texturepacker.jar ${escapedLink}`);
             } catch {
                 throw new Error("Failed to download runnable-texturepacker.jar!");
             }


### PR DESCRIPTION
Adds 'await' to ensure the download will be complete.

Without this the download might never complete. This issue occurred on a Linux OS (which seem to handle file streams a bit different than some other OSs). Effects of not fixing this are that the java execution following this download fails for funny "corrupted jar" and other reasons - depending on the size and content of the incomplete jar file.

---

I am no professional web developer. This seems like an obvious fix given the symptoms I experienced. Please validate that this fix makes sense and is properly executed.
Please let me know, if anything should be changed - I will fix it according to request.