### PR TITLE
Fix some issues with the Electron wrapper refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ and does not intend to provide compatibility for older clients.
 -   Run `yarn` in the root folder and in `electron/`.
 -   Run `yarn gulp` in the root folder to build and serve files.
     Ignore the browser tab that opens.
--   Open a new terminal and run `yarn startDev` in `electron/` to open an Electron window.
+-   Open a new terminal and run `yarn start` in `electron/` to open an Electron window.
     -   Tip: If you open the Electron window too early, you can reload it when focused on DevTools.
 
 ### Release

--- a/electron/package.json
+++ b/electron/package.json
@@ -10,6 +10,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "electron": "^31.3.0"
+        "electron": "^31.3.0",
+        "typescript": "^5.4.5"
     }
 }

--- a/electron/package.json
+++ b/electron/package.json
@@ -11,6 +11,6 @@
     "dependencies": {},
     "devDependencies": {
         "electron": "^31.3.0",
-        "typescript": "^5.4.5"
+        "typescript": "^5.8.2"
     }
 }

--- a/electron/src/fsjob.ts
+++ b/electron/src/fsjob.ts
@@ -49,6 +49,10 @@ export class FsJobHandler {
     }
 
     private async write(file: string, contents: string): Promise<string> {
+        // The target directory might not exist, ensure it does
+        const parentDir = path.dirname(file);
+        await fs.mkdir(parentDir, { recursive: true });
+
         // Backups not implemented yet.
         await fs.writeFile(file, contents, {
             encoding: "utf-8",

--- a/electron/src/index.ts
+++ b/electron/src/index.ts
@@ -65,6 +65,12 @@ function createWindow() {
         ev.preventDefault();
         openExternalUrl(url);
     });
+
+    // Also redirect window.open
+    win.webContents.setWindowOpenHandler(({ url }) => {
+        openExternalUrl(url);
+        return { action: "deny" };
+    });
 }
 
 function openExternalUrl(urlString: string) {

--- a/electron/yarn.lock
+++ b/electron/yarn.lock
@@ -495,10 +495,10 @@ type-fest@^0.13.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
   integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
-typescript@5.4.5:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@^5.8.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
+  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
 undici-types@~5.26.4:
   version "5.26.5"

--- a/electron/yarn.lock
+++ b/electron/yarn.lock
@@ -495,6 +495,11 @@ type-fest@^0.13.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.13.1.tgz#0172cb5bce80b0bd542ea348db50c7e21834d934"
   integrity sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
 
+typescript@5.4.5:
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
+  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "strip-json-comments": "^3.0.1",
         "terser-webpack-plugin": "^5.3.6",
         "ts-loader": "^9.4.2",
-        "typescript": "^5.4.5",
+        "typescript": "^5.8.2",
         "typescript-eslint": "^7.7.1",
         "webpack": "^5.75.0",
         "webpack-deadcode-plugin": "^0.1.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9799,10 +9799,10 @@ typescript@^4.6.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
   integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
 
-typescript@^5.4.5:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
-  integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
+typescript@^5.8.2:
+  version "5.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
+  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
 ua-parser-js@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Addresses some of the issues mentioned in https://github.com/tobspr-games/shapez-community-edition/pull/47#pullrequestreview-2716131449. Fortunately the fixes are relatively simple.
- Update README with the correct Electron start command
- Add `typescript` to Electron wrapper devDependencies (type stripping is not there yet)
- Create missing directories before writing files (not atomic, but good enough)
- Redirect window.open to external browser (the intended behavior subject to change)