### PR TITLE
Fix disappearing window menu on Linux

### DIFF
--- a/electron/src/ipc.ts
+++ b/electron/src/ipc.ts
@@ -29,6 +29,8 @@ export class IpcHandler {
     }
 
     private setFullscreen(window: BrowserWindow, _event: IpcMainInvokeEvent, flag: boolean) {
-        window.setFullScreen(flag);
+        if (window.isFullScreen() != flag) {
+            window.setFullScreen(flag);
+        }
     }
 }


### PR DESCRIPTION
TL;DR: This is a workaround for an Electron bug which causes menus to disappear when using `BrowserWindow#setFullscreen(false)`.

Electron is supposed to hide the window menu when fullscreen is entered on Linux (the latest versions also does this on Windows) and restore it when exiting fullscreen mode. However, if one calls setFullscreen(false) while the window is not in fullscreen mode, the menu is gone. This seems to be a bug in this version of Electron. In our case, this is triggered by the game loading process - quite annoying.

The fix is easy: just check the state of fullscreen and do nothing if the desired state is already achieved.