### PR TITLE
Fix unhandled savegame loading error

### DIFF
--- a/src/js/states/main_menu.js
+++ b/src/js/states/main_menu.js
@@ -138,14 +138,14 @@ export class MainMenuState extends GameState {
         const closeLoader = this.dialogs.showLoadingDialog();
         await waitNextFrame();
 
-        const data = await this.app.storage.requestOpenFile("bin");
-        if (data === undefined) {
-            // User canceled the request
-            closeLoader();
-            return;
-        }
-
         try {
+            const data = await this.app.storage.requestOpenFile("bin");
+            if (data === undefined) {
+                // User canceled the request
+                closeLoader();
+                return;
+            }
+
             this.app.savegameMgr.importSavegame(data);
             closeLoader();
             this.dialogs.showWarning(


### PR DESCRIPTION
My initial implementation failed to account for errors thrown by the Storage API. This is a simple fix that moves relevant code into existing try/catch block. Not handling such an error means the loader is never closed, and the user must restart the game to do anything. With the fix applied, a usual savegame loading error dialog is shown.