### PR TITLE
Implement worker for save decompression

### DIFF
--- a/electron/src/storage/saves.ts
+++ b/electron/src/storage/saves.ts
@@ -1,7 +1,7 @@
-import { decodeAsync, encode } from "@msgpack/msgpack";
+import { encode } from "@msgpack/msgpack";
 import fs from "node:fs";
 import { pipeline } from "node:stream/promises";
-import { createGunzip, createGzip } from "node:zlib";
+import { createGzip } from "node:zlib";
 import { StorageInterface } from "./interface.js";
 
 /**
@@ -10,27 +10,7 @@ import { StorageInterface } from "./interface.js";
  */
 export class SavesStorage implements StorageInterface<unknown> {
     async read(file: string): Promise<unknown> {
-        const stream = fs.createReadStream(file);
-        const gunzip = createGunzip();
-
-        try {
-            // Any filesystem errors will be uncovered here. This code ensures we return the most
-            // relevant rejection, or resolve with the decoded data
-            const [readResult, decodeResult] = await Promise.allSettled([
-                pipeline(stream, gunzip),
-                decodeAsync(gunzip),
-            ]);
-
-            if (decodeResult.status === "fulfilled") {
-                return decodeResult.value;
-            }
-
-            // Return the most relevant error
-            throw readResult.status === "rejected" ? readResult.reason : decodeResult.reason;
-        } finally {
-            stream.close();
-            gunzip.close();
-        }
+        return fs.promises.readFile(file);
     }
 
     async write(file: string, contents: unknown): Promise<void> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.6.0",
             "license": "GPL-3.0-or-later",
             "dependencies": {
+                "@msgpack/msgpack": "^3.1.1",
                 "ajv": "^6.10.2",
                 "circular-json": "^0.5.9",
                 "clipboard-copy": "^3.1.0",
@@ -656,6 +657,15 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@msgpack/msgpack": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
+            "integrity": "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 18"
             }
         },
         "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "clipboard-copy": "^3.1.0",
         "debounce-promise": "^3.1.2",
         "howler": "^2.1.2",
-        "lz-string": "^1.4.4"
+        "lz-string": "^1.4.4",
+        "@msgpack/msgpack": "^3.1.1"
     },
     "devDependencies": {
         "@eslint/js": "^9.24.0",

--- a/src/js/platform/storage.ts
+++ b/src/js/platform/storage.ts
@@ -1,8 +1,14 @@
 import { Application } from "@/application";
 import { FsError } from "./fs_error";
 
+// @ts-expect-error This works in the animation_frame file so it has to work here too, right?
+import DecompressionWorker from "../webworkers/decompression.worker"
+
 export const STORAGE_SAVES = "saves";
 export const STORAGE_MOD_PREFIX = "mod/";
+
+const DECOMPRESSION_IDS = [ STORAGE_SAVES ]
+const decompression_worker = new DecompressionWorker()
 
 export class Storage {
     readonly app: Application;
@@ -28,10 +34,26 @@ export class Storage {
     }
 
     /**
+     * Tries to decompress a string
+     */
+    private async decompress(data) {
+        if (!DECOMPRESSION_IDS.includes(this.id))
+            return data
+        let array = await data
+        return new Promise((resolve, reject) => {
+            decompression_worker.onmessage = (event: MessageEvent<unknown>) => {
+                resolve(event.data)
+            }
+            decompression_worker.onerror = (_event) => reject()
+            decompression_worker.postMessage(array, [array.buffer])
+        })
+    }
+
+    /**
      * Reads a string asynchronously
      */
-    readFileAsync(filename: string): Promise<unknown> {
-        return this.invokeFsJob({ type: "read", filename });
+    async readFileAsync(filename: string): Promise<unknown> {
+        return this.decompress(this.invokeFsJob({ type: "read", filename }))
     }
 
     /**
@@ -45,8 +67,8 @@ export class Storage {
      * Displays the "Open File" dialog to let user pick a file. Returns the
      * decompressed file contents, or undefined if the operation was canceled
      */
-    requestOpenFile(extension: string): Promise<unknown> {
-        return this.invokeFsJob({ type: "open-external", extension });
+    async requestOpenFile(extension: string): Promise<unknown> {
+        return this.decompress(this.invokeFsJob({ type: "open-external", extension }))
     }
 
     /**

--- a/src/js/webworkers/decompression.worker.js
+++ b/src/js/webworkers/decompression.worker.js
@@ -1,0 +1,16 @@
+import { decodeAsync } from "@msgpack/msgpack";
+
+onmessage = (event) => {
+    console.time("Compression")
+    const decompressionStream = new DecompressionStream("gzip")
+    const stream = new ReadableStream({
+        start(controller) {
+            controller.enqueue(event.data);
+            controller.close();
+        }
+    });
+    decodeAsync(stream.pipeThrough(decompressionStream)).then(val => {
+        postMessage(val)
+        console.timeEnd("Compression")
+    })
+}


### PR DESCRIPTION
Dengr1065 had a plan for an issue related to the new gzipped MessagePack savegame storage.
It would hang the main process for too long and their plan was to have all the decompression be done in a worker thread on the renderer process so nothing would hang.
I simply executed that plan because he was too "lazy" to do it.