### PR TITLE
Basic FS watcher for --load-mod mods

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "dependencies": {
+                "chokidar": "^4.0.3",
                 "semver": "^7.7.1",
                 "zod": "^3.24.2"
             },
@@ -190,6 +191,21 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/clone-response": {
@@ -731,6 +747,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/resolve-alpn": {

--- a/electron/package.json
+++ b/electron/package.json
@@ -9,6 +9,7 @@
         "start": "tsc && electron ."
     },
     "dependencies": {
+        "chokidar": "^4.0.3",
         "semver": "^7.7.1",
         "zod": "^3.24.2"
     },

--- a/electron/src/index.ts
+++ b/electron/src/index.ts
@@ -56,6 +56,12 @@ function createWindow() {
     ipc.install(window);
     window.loadURL(pageUrl);
 
+    modLoader.on("forcereload", () => {
+        // TODO: Find a better way to manage cache when force
+        // reloading (use a non-persistent session?)
+        window.webContents.session.clearData({ dataTypes: ["cache"] }).then(() => window.reload());
+    });
+
     // Redirect any kind of main frame navigation to external applications
     window.webContents.on("will-navigate", (ev, url) => {
         if (url === window.webContents.getURL()) {


### PR DESCRIPTION
Add a --watch command line flag to be used in tandem with --load-mod. Chokidar is used to detect file updates, and a page reload is triggered when there are any changes to watched mod files. Only mods loaded via --load-mod are affected.

This implementation has a minor issue with how cache is cleared - removing disk cache is a bit too aggressive - but the only alternative I could find is to use a non-persistent Electron session, which would get rid of disk cache entirely (this is not a concern).

The way watcher events are propagated is somewhat dirty (using an EventEmitter without any typings), but it's good enough in my opinion.