### PR TITLE
Added gameInitialized check to onEntityChanged in map_view.js

### DIFF
--- a/src/js/game/map_view.js
+++ b/src/js/game/map_view.js
@@ -51,6 +51,10 @@ export class MapView extends BaseMap {
      * @param {Entity} entity
      */
     onEntityChanged(entity) {
+        if (!this.root.gameInitialized) {
+            return;
+        }
+
         const staticComp = entity.components.StaticMapEntity;
         if (staticComp) {
             const rect = staticComp.getTileSpaceBounds();


### PR DESCRIPTION
onEntityChanged function gets called for each entity change, including placing a new one. Its purpose is to find each chunk that is occupied by that updated entity and set that chunk as dirty. This function gets called several times while the game is loading the save file, but newly generated chunks are all initialized as dirt already. So it is just checking these newly generated chunks and setting them as dirty even though they are dirty already. This little check stops this from happening!