### PR TITLE
Implement custom debounce for --watch force reload

### DIFF
--- a/electron/src/mods/locator.ts
+++ b/electron/src/mods/locator.ts
@@ -179,8 +179,6 @@ export class DevelopmentModLocator implements ModLocator {
         this.fsWatcher = chokidar.watch(this.modFiles, {
             persistent: false,
             ignoreInitial: true,
-            awaitWriteFinish: true,
-            atomic: true,
         });
     }
 


### PR DESCRIPTION
The options used for chokidar initialization were not enough to prevent double reloads, often causing both an instant reload and a 2s delayed one. With these changes there is no longer any debouncing on chokidar side and as we don't actually care about the specific file changed, this should work much better. This is mostly relevant for environments where the entire build folder is regenerated when bundling.

The only downside to this approach is a hardcoded settle time of 250ms, but it can be adjusted if needed or exposed as yet another command-line switch.