### PR TITLE
Do not open developer tools automatically

### DIFF
--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -18,6 +18,5 @@ export const pageUrl = app.isPackaged
 
 export const switches = {
     dev: app.commandLine.hasSwitch("dev"),
-    hideDevtools: app.commandLine.hasSwitch("hide-devtools"),
     safeMode: app.commandLine.hasSwitch("safe-mode"),
 };

--- a/electron/src/index.ts
+++ b/electron/src/index.ts
@@ -47,10 +47,6 @@ function createWindow() {
 
     window.on("ready-to-show", () => {
         window.show();
-
-        if (switches.dev && !switches.hideDevtools) {
-            window.webContents.openDevTools();
-        }
     });
 
     ipc.install(window);


### PR DESCRIPTION
Most hated feature. Using `--hide-devtools` every time can be quite annoying, while the default behavior is also annoying: if the page is reloaded, developer tools open again. This PR removes this behavior entirely along with the `--hide-devtools` switch.