### PR TITLE
Always detach HUDSettingsMenu input receiver

### DIFF
--- a/src/js/game/hud/parts/settings_menu.js
+++ b/src/js/game/hud/parts/settings_menu.js
@@ -123,6 +123,13 @@ export class HUDSettingsMenu extends BaseHUDPart {
         this.update();
     }
 
+    cleanup() {
+        super.cleanup();
+
+        // Detach the input receiver when leaving InGameState
+        this.root.app.inputMgr.makeSureDetached(this.inputReceiver);
+    }
+
     update() {
         this.domAttach.update(this.visible);
     }


### PR DESCRIPTION
Before the changes in this PR, `HUDSettingsMenu` did not detach its input receiver when the settings or exit buttons got pressed. This behavior does not cause any problems, however the input receiver stays in the stack indefinitely. With this PR, settings menu input receiver is always detached while leaving `InGameState`.