### PR TITLE
Add desktopName to package.json

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "electron",
+    "name": "shapez-ce",
     "version": "1.0.0",
     "license": "MIT",
     "desktopName": "io.shapez.community.desktop",

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -5,7 +5,6 @@ const disabledFeatures = ["HardwareMediaKeyHandling"];
 app.commandLine.appendSwitch("disable-features", disabledFeatures.join(","));
 
 export const defaultWindowTitle = "shapez CE";
-app.setName("shapez-ce");
 
 // This variable should be used to avoid situations where the app name
 // wasn't set yet.


### PR DESCRIPTION
This entry is used to correctly set app-id in Wayland and WM_CLASS in X11. Otherwise it defaults to "electron".