### PR TITLE
Update Electron (minor change)

### DIFF
--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -15,7 +15,7 @@
             },
             "devDependencies": {
                 "@types/semver": "^7.7.0",
-                "electron": "^37.2.3",
+                "electron": "^37.6.1",
                 "typescript": "^5.8.2"
             }
         },
@@ -325,9 +325,9 @@
             "optional": true
         },
         "node_modules/electron": {
-            "version": "37.2.3",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-37.2.3.tgz",
-            "integrity": "sha512-JRKKn8cRDXDfkC+oWISbYs+c+L6RA776JM0NiB9bn2yV8H/LnBUlVPzKKfsXgrUIokN4YcbCw694vfAdEJwtGw==",
+            "version": "37.6.1",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-37.6.1.tgz",
+            "integrity": "sha512-aHtJVNjqf0lk7dlPoc1X+fMBpZtLn+XGvP6IYc3gooTwsD1D/Ic2SBRC9SnIk6LkWTsDaSF9jgH1d9Q7eABy/Q==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",

--- a/electron/package.json
+++ b/electron/package.json
@@ -16,7 +16,7 @@
     },
     "devDependencies": {
         "@types/semver": "^7.7.0",
-        "electron": "^37.2.3",
+        "electron": "^37.6.1",
         "typescript": "^5.8.2"
     }
 }


### PR DESCRIPTION
There were no reports about poor performance on macOS 26, but it's likely a good idea to update just in case there is high GPU load on the current releases and nobody noticed it yet.