### PR TITLE
Introduce draw hooks for wires foreground layer

### DIFF
--- a/src/js/game/map_chunk_view.js
+++ b/src/js/game/map_chunk_view.js
@@ -17,6 +17,9 @@ export const MOD_CHUNK_DRAW_HOOKS = {
 
     staticBefore: [],
     staticAfter: [],
+
+    wiresForegroundBefore: [],
+    wiresForegroundAfter: [],
 };
 
 export class MapChunkView extends MapChunk {
@@ -300,8 +303,17 @@ export class MapChunkView extends MapChunk {
      */
     drawWiresForegroundLayer(parameters) {
         const systems = this.root.systemMgr.systems;
+
+        MOD_CHUNK_DRAW_HOOKS.wiresForegroundBefore.forEach(systemId =>
+            systems[systemId].drawWiresChunk(parameters, this)
+        );
+
         systems.wire.drawChunk(parameters, this);
         systems.staticMapEntities.drawWiresChunk(parameters, this);
         systems.wiredPins.drawChunk(parameters, this);
+
+        MOD_CHUNK_DRAW_HOOKS.wiresForegroundAfter.forEach(systemId =>
+            systems[systemId].drawWiresChunk(parameters, this)
+        );
     }
 }


### PR DESCRIPTION
No code cleanups here for now, but it might be good to refactor the draw hook interface slightly in the future. This PR only adds two draw hooks: `wiresForegroundBefore` and `wiresForegroundAfter` so that mods can render stuff on wires layer without rAM/rBM. I chose `drawWiresChunk` as the called method name because this allows the same system to register both regular and wires layers draw hooks at the same time.

The mod code I used for testing:
```js
class WiresRenderTestSystem extends shapez.GameSystem {
  drawWiresChunk(parameters, chunk) {
    const ctx = parameters.context;
    const text = `Chunk ${chunk.x}, ${chunk.y}`;
    const { x, y } = new shapez.Vector(chunk.tileX, chunk.tileY).toWorldSpace();

    ctx.save();
    ctx.fillStyle = "white";
    ctx.fillText(text, x, y);
    ctx.restore();
  }
}

export default class extends shapez.Mod {
  init() {
    this.modInterface.registerGameSystem({
      id: `${this.id}:testSystem`,
      systemClass: WiresRenderTestSystem,
      before: "constantSignal",
      drawHooks: ["wiresForegroundBefore"],
    });
  }
}
```