### PR TITLE
Allow pasting cut blueprints once

### DIFF
--- a/src/js/game/hud/hud.js
+++ b/src/js/game/hud/hud.js
@@ -38,7 +38,7 @@ export class GameHUD {
             shapePinRequested: /** @type {Signal<[ShapeDefinition]>} */ (new Signal()),
             shapeUnpinRequested: /** @type {Signal<[string]>} */ (new Signal()),
             notification: /** @type {Signal<[string, enumNotificationType]>} */ (new Signal()),
-            buildingsSelectedForCopy: /** @type {Signal<[Array<number>]>} */ (new Signal()),
+            buildingsSelectedForBlueprint: /** @type {Signal<[Array<number>, boolean]>} */ (new Signal()),
             pasteBlueprintRequested: /** @type {Signal<[]>} */ (new Signal()),
             viewShapeDetailsRequested: /** @type {Signal<[ShapeDefinition]>} */ (new Signal()),
             unlockNotificationFinished: /** @type {Signal<[]>} */ (new Signal()),

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -124,7 +124,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         this.root.gameState.inputReceiver.keyup.add(this.checkForDirectionLockSwitch, this);
 
         // BINDINGS TO GAME EVENTS
-        this.root.hud.signals.buildingsSelectedForCopy.add(this.abortPlacement, this);
+        this.root.hud.signals.buildingsSelectedForBlueprint.add(this.abortPlacement, this);
         this.root.hud.signals.pasteBlueprintRequested.add(this.abortPlacement, this);
         this.root.signals.storyGoalCompleted.add(() => this.signals.variantChanged.dispatch());
         this.root.signals.upgradePurchased.add(() => this.signals.variantChanged.dispatch());


### PR DESCRIPTION
As proposed by @chunkybanana. After making a selection and triggering the cut action, a blueprint will be created with special `isNextPasteFree` flag (also open for modding purposes) which is automatically reset when a blueprint is successfully pasted (i.e. when at least one building was placed). This PR also contains a minor rearrangement of responsibilities: the `Blueprint#tryPlace` method is now responsible for deducting the blueprint cost, the Blueprint class now also includes a helper method for checking if a blueprint is free. External usages of `getHasFreeCopyPaste` have been replaced with that method or removed entirely in cases where `canAfford` could be the single source of truth.