### PR TITLE
Update Prettier VS Code extension ID

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["esbenp.prettier-vscode", "EditorConfig.EditorConfig", "dbaeumer.vscode-eslint"]
+    "recommendations": ["prettier.prettier-vscode", "EditorConfig.EditorConfig", "dbaeumer.vscode-eslint"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.defaultFormatter": "prettier.prettier-vscode",
     "files.trimTrailingWhitespace": true,
     "editor.formatOnSave": true,
     "files.exclude": {


### PR DESCRIPTION
The Prettier extension ID was recently changed from `esbenp.prettier-vscode` to `prettier.prettier-vscode`. This PR updates the recommended extension list (extensions.json) and default formatter override for workspace (settings.json) to use the new Prettier extension rather than the legacy one.