### PR TITLE
Remove clipboard-copy runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
             "dependencies": {
                 "@msgpack/msgpack": "^3.1.2",
                 "ajv": "^6.10.2",
-                "clipboard-copy": "^3.1.0",
                 "debounce-promise": "^3.1.2",
                 "howler": "^2.1.2"
             },
@@ -3437,6 +3436,17 @@
                 "node": ">=8"
             }
         },
+        "node_modules/bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "node_modules/bl": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
@@ -4308,26 +4318,6 @@
             "engines": {
                 "node": ">= 4.0"
             }
-        },
-        "node_modules/clipboard-copy": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-3.2.0.tgz",
-            "integrity": "sha512-vooFaGFL6ulEP1liiaWFBmmfuPm3cY3y7T9eB83ZTnYc/oFeAKsq3NcDrOkBC8XaauEE8zHQwI7k0+JSYiVQSQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -7241,6 +7231,14 @@
                 "node": ">=4"
             }
         },
+        "node_modules/file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/filename-reserved-regex": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
@@ -7646,6 +7644,21 @@
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/function-bind": {
             "version": "1.1.1",
@@ -8224,6 +8237,26 @@
             },
             "optionalDependencies": {
                 "fsevents": "^1.2.7"
+            }
+        },
+        "node_modules/glob-watcher/node_modules/fsevents": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+            "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+            "deprecated": "Upgrade to fsevents v2 to mitigate potential security issues",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "dependencies": {
+                "bindings": "^1.5.0",
+                "nan": "^2.12.1"
+            },
+            "engines": {
+                "node": ">= 4.0"
             }
         },
         "node_modules/glob-watcher/node_modules/glob-parent": {
@@ -12656,6 +12689,14 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/nan": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
+            "integrity": "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/nanomatch": {
             "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "dependencies": {
         "@msgpack/msgpack": "^3.1.2",
         "ajv": "^6.10.2",
-        "clipboard-copy": "^3.1.0",
         "debounce-promise": "^3.1.2",
         "howler": "^2.1.2"
     },

--- a/src/js/core/error_handler.tsx
+++ b/src/js/core/error_handler.tsx
@@ -1,6 +1,5 @@
 import { MODS } from "@/mods/modloader";
 import { T } from "@/translations";
-import copy from "clipboard-copy";
 import { BUILD_OPTIONS } from "./globals";
 import { removeAllChildren } from "./utils";
 
@@ -101,7 +100,7 @@ export class ErrorScreen {
         log += `\n\nLoaded Mods:\n${this.loadedMods}`;
         log += `\n\nBuild Information:\n${this.buildInformation}`;
 
-        copy(log);
+        navigator.clipboard.writeText(log);
 
         if (ev.target instanceof HTMLButtonElement) {
             ev.target.innerText = T.errorHandler.actions.copyDone;

--- a/src/js/game/hud/parts/shape_viewer.js
+++ b/src/js/game/hud/parts/shape_viewer.js
@@ -6,8 +6,6 @@ import { ShapeDefinition } from "../../shape_definition";
 import { BaseHUDPart } from "../base_hud_part";
 import { DynamicDomAttach } from "../dynamic_dom_attach";
 
-import copy from "clipboard-copy";
-
 export class HUDShapeViewer extends BaseHUDPart {
     createElements(parent) {
         this.background = makeDiv(parent, "ingame_HUD_ShapeViewer", ["ingameDialog"]);
@@ -57,7 +55,7 @@ export class HUDShapeViewer extends BaseHUDPart {
      */
     onCopyKeyRequested() {
         if (this.currentShapeKey) {
-            copy(this.currentShapeKey);
+            navigator.clipboard.writeText(this.currentShapeKey);
             this.close();
         }
     }

--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -8,7 +8,6 @@ import { KEYMAPPINGS } from "../../key_action_mapper";
 import { enumHubGoalRewards } from "../../tutorial_goals";
 import { BaseHUDPart } from "../base_hud_part";
 
-import copy from "clipboard-copy";
 const wiresBackgroundDpi = 4;
 
 export class HUDWiresOverlay extends BaseHUDPart {
@@ -103,10 +102,10 @@ export class HUDWiresOverlay extends BaseHUDPart {
         }
 
         if (value) {
-            copy(value.getAsCopyableKey());
+            navigator.clipboard.writeText(value.getAsCopyableKey());
             this.root.soundProxy.playUi(SOUNDS.copy);
         } else {
-            copy("");
+            navigator.clipboard.writeText("");
             this.root.soundProxy.playUiError();
         }
     }

--- a/src/js/game/modes/puzzle_play.js
+++ b/src/js/game/modes/puzzle_play.js
@@ -33,7 +33,6 @@ import { gMetaBuildingRegistry } from "../../core/global_registries";
 import { HUDPuzzleNextPuzzle } from "../hud/parts/next_puzzle";
 
 const logger = createLogger("puzzle-play");
-import copy from "clipboard-copy";
 
 export class PuzzlePlayGameMode extends PuzzleGameMode {
     static getId() {
@@ -157,7 +156,7 @@ export class PuzzlePlayGameMode extends PuzzleGameMode {
     }
 
     sharePuzzle() {
-        copy(this.puzzle.meta.shortKey);
+        navigator.clipboard.writeText(this.puzzle.meta.shortKey);
 
         this.root.hud.parts.dialogs.showInfo(
             T.dialogs.puzzleShare.title,


### PR DESCRIPTION
Replaces uses of `copy()` from clipboard-copy with `navigator.clipboard.writeText()`. Removes clipboard-copy.

I believe this is a welcome change because it:
- Does not add any complexity
- Removes a runtime dependency
- Functions the same as before (as long as the copy succeeds [which it should because we are using a recent version of Chromium and a secure context]) 

Furthermore, it remains compatible with web platforms in case someday they become supported again, unlike using an Electron API.