### PR TITLE
Add configuration for Zed editor

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 charset = utf-8

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "editor.defaultFormatter": "prettier.prettier-vscode",
-    "files.trimTrailingWhitespace": true,
     "editor.formatOnSave": true,
     "files.exclude": {
         "**/.git": true,

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,17 @@
+{
+    "format_on_save": "on",
+    "file_scan_exclusions": [
+        "**/.git",
+        "**/.DS_Store",
+        "**/Thumbs.db",
+        "node_modules",
+        "build",
+        "build_output"
+    ],
+    "formatter": {
+        "external": {
+            "command": "npx",
+            "arguments": ["prettier", "--stdin-filepath", "{buffer_path}"]
+        }
+    }
+}


### PR DESCRIPTION
Also move a config from VS Code settings to .editorconfig
Formatting with Prettier is a bit hacky on Zed, but it should improve if/when we upgrade to something like biome or oxfmt.
Eslint works fine out-of-the-box.