### PR TITLE
Revert "Update .vscode Prettier suggestion"

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["prettier.prettier-vscode", "EditorConfig.EditorConfig", "dbaeumer.vscode-eslint"]
+    "recommendations": ["esbenp.prettier-vscode", "EditorConfig.EditorConfig", "dbaeumer.vscode-eslint"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-    "editor.defaultFormatter": "prettier.prettier-vscode",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
     "files.exclude": {
         "**/.git": true,


### PR DESCRIPTION
Didn't do enough research before applying this change. It looks like the namespace migration isn't going to happen: https://github.com/prettier/prettier-vscode/issues/3872#issuecomment-3662898646