### PR TITLE
Add Docker build environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+electron/node_modules
+build_output
+build
+gulp/res_built
+src/js/built-temp
+gulp/runnable-texturepacker.jar
+.vscode
+.zed
+*.log
+.env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,26 @@ jobs:
               uses: ibiqlik/action-yamllint@v1.0.0
               with:
                   file_or_dir: translations/*.yaml
+
+    build:
+        name: build
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v2
+            - name: Build Docker image
+              env:
+                  DOCKER_BUILDKIT: 1
+              run: docker build -t shapez-ce-builder .
+            - name: Build linux-x64 and win32-x64
+              run: >
+                docker run --rm
+                -v ${{ github.workspace }}/build_output:/output
+                shapez-ce-builder
+                package.standalone.linux-x64
+                package.standalone.win32-x64
+            - name: Upload build artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: standalone
+                  path: build_output/standalone

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
                 shapez-ce-builder
                 package.standalone.linux-x64
                 package.standalone.win32-x64
+            - name: Fix artifact permissions
+              run: sudo chown -R "$(id -u):$(id -g)" build_output
             - name: Upload build artifacts
               uses: actions/upload-artifact@v4
               with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,31 @@
-FROM node:16
-
-EXPOSE 3001 3005
-
-WORKDIR /shapez.io
+# syntax=docker/dockerfile:1
+# docker build -t shapez-ce-builder .
+ARG TARGETPLATFORM=linux/amd64
+FROM --platform=$TARGETPLATFORM node:22-bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg default-jre \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    ffmpeg default-jre git \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-COPY package.json yarn.lock ./
-RUN yarn
+WORKDIR /app
 
+COPY package.json package-lock.json ./
 COPY gulp ./gulp
-WORKDIR /shapez.io/gulp
-RUN yarn
+COPY src ./src
 
-WORKDIR /shapez.io
-COPY res ./res
-COPY src/html ./src/html
-COPY src/css ./src/css
-COPY sync-translations.js ./
-COPY translations ./translations
-COPY src/js ./src/js
-COPY res_raw ./res_raw
-COPY .git ./.git
-COPY electron ./electron
+RUN --mount=type=cache,target=/root/.npm \
+    --mount=type=cache,target=/tmp/jar-cache \
+    (cp /tmp/jar-cache/runnable-texturepacker.jar gulp/ 2>/dev/null || true) && \
+    npm ci && \
+    (cp gulp/runnable-texturepacker.jar /tmp/jar-cache/ 2>/dev/null || true)
 
-WORKDIR /shapez.io/gulp
-ENTRYPOINT ["yarn", "gulp"]
+COPY electron/package.json electron/package-lock.json electron/
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --prefix electron --ignore-scripts
+
+COPY . .
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ and does not intend to provide compatibility for older clients.
     -   `$ARCH` is the target system architecture (`x64` or `arm64`)
 -   The build will be found under `build_output/standalone` as `shapez-...`.
 
+### Building with Docker
+
+You can build without installing Node, Java, or ffmpeg on the host. From the repo root, build the image and run a package task with a volume so output appears in `build_output/` on your machine:
+
+```bash
+docker build -t shapez-ce-builder .
+docker run --rm -v "$(pwd)/build_output:/output" shapez-ce-builder package.standalone.linux-x64
+```
+
+On Apple Silicon add `--platform linux/amd64` to the build command. For other targets use e.g. `package.standalone.win32-x64`. Darwin builds are best done on macOS.
+
 ## Credits
 
 Thanks to [tobspr](https://tobspr.io) for creating this project!

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Run gulp task(s), then copy build_output to /output when present.
+exitcode=0
+if [ $# -eq 0 ]; then
+  npm run gulp -- "$@"
+  exitcode=$?
+else
+  for task in "$@"; do
+    npm run gulp -- "$task" || exitcode=$?
+    [ $exitcode -ne 0 ] && break
+  done
+fi
+if [ -d /output ] && [ -d /app/build_output ]; then
+  cp -r /app/build_output/. /output
+fi
+exit $exitcode

--- a/gulp/environment.js
+++ b/gulp/environment.js
@@ -35,7 +35,8 @@ export async function downloadTexturePacker() {
         throw new Error(`Failed to download Texture Packer: ${response.statusText}`);
     }
 
-    await fs.writeFile(destination, response.body);
+    const buffer = Buffer.from(await response.arrayBuffer());
+    await fs.writeFile(destination, buffer);
 }
 
 export async function createLocalConfig() {

--- a/gulp/environment.js
+++ b/gulp/environment.js
@@ -1,6 +1,9 @@
 import { exec } from "child_process";
+import { createWriteStream } from "fs";
 import fs from "fs/promises";
 import gulp from "gulp";
+import { Readable } from "stream";
+import { pipeline } from "stream/promises";
 import { promisify } from "util";
 
 const texturePackerUrl =
@@ -35,8 +38,7 @@ export async function downloadTexturePacker() {
         throw new Error(`Failed to download Texture Packer: ${response.statusText}`);
     }
 
-    const buffer = Buffer.from(await response.arrayBuffer());
-    await fs.writeFile(destination, buffer);
+    await pipeline(Readable.fromWeb(response.body), createWriteStream(destination));
 }
 
 export async function createLocalConfig() {


### PR DESCRIPTION
Following up on @dengr1065’s request in #57. This PR aims to close #57.

This adds an optional Docker setup so the game can be built in a clean, reproducible environment instead of depending on local prerequisites (which tend to drift, especially across distros and CI).

The container bundles the required toolchain and runs the packaging tasks, making builds easier to reproduce and avoiding leftover state after failures. CI support and a short README section are included.

Happy to tweak if there’s a preferred approach.