### PR TITLE
Remove JSX dev runtime

### DIFF
--- a/gulp/rspack.config.js
+++ b/gulp/rspack.config.js
@@ -47,6 +47,7 @@ const moduleRules = [
                         transform: {
                             react: {
                                 runtime: "automatic",
+                                development: false,
                                 importSource: "@",
                             },
                         },

--- a/gulp/rspack.production.config.js
+++ b/gulp/rspack.production.config.js
@@ -54,6 +54,7 @@ const moduleRules = [
                         transform: {
                             react: {
                                 runtime: "automatic",
+                                development: false,
                                 importSource: "@",
                             },
                         },

--- a/src/js/jsx-dev-runtime.ts
+++ b/src/js/jsx-dev-runtime.ts
@@ -1,2 +1,0 @@
-import { Fragment, jsx } from "./jsx-runtime";
-export { Fragment, jsx as jsxDEV };

--- a/src/js/mods/modloader.ts
+++ b/src/js/mods/modloader.ts
@@ -103,7 +103,7 @@ export class ModLoader {
             regExp: /\.[jt]sx?$/,
             // NOTE: Worker scripts are executed if not explicitly excluded, which causes
             // infinite recursion!
-            exclude: /\/webworkers\/|\.d\.ts$|jsx-dev-runtime\.ts$/,
+            exclude: /\/webworkers\/|\.d\.ts$/,
         });
 
         Array.from(modules.keys()).forEach(key => {


### PR DESCRIPTION
The JSX dev runtime was added during the transition to Rspack. It is completely redundant, and I have now learned how to build successfully without it.