### PR TITLE
Specify `once` for initial load event listener

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -53,4 +53,4 @@ function bootApp() {
     app.boot();
 }
 
-window.addEventListener("load", bootApp);
+window.addEventListener("load", bootApp, { once: true });


### PR DESCRIPTION
This makes so that there is no lingering event listener for `load`, which should never be fired multiple times.