### PR TITLE
Fix type of `children` of a JSX element

### DIFF
--- a/src/js/globals.d.ts
+++ b/src/js/globals.d.ts
@@ -90,8 +90,8 @@ declare namespace JSX {
      */
     type IntrinsicElements = {
         [K in keyof HTMLElementTagNameMap]: {
-            children?: JSXNode | JSXNode[];
-            [k: string]: JSXNode | JSXNode[] | string | number | boolean;
+            children?: JSXNode | JSXNodes;
+            [k: string]: JSXNode | JSXNodes | string | number | boolean;
         };
     };
     /**
@@ -117,4 +117,9 @@ declare namespace JSX {
      * A child of a JSX element.
      */
     type JSXNode = Node | string | boolean | null | undefined;
+
+    /**
+     * A group of children of a JSX element.
+     */
+    type JSXNodes = (JSXNode | JSXNodes)[];
 }


### PR DESCRIPTION
The JSX runtime correctly handles elements having nested arrays of children, but the typing did not reflect this. This PR resolves that issue.