### PR TITLE
Make .jsx files work again

### DIFF
--- a/gulp/rspack.config.js
+++ b/gulp/rspack.config.js
@@ -44,6 +44,7 @@ const moduleRules = [
                 options: {
                     jsc: {
                         target: "es2024",
+                        parser: { syntax: "typescript", tsx: true },
                         transform: {
                             react: {
                                 runtime: "automatic",

--- a/gulp/rspack.config.js
+++ b/gulp/rspack.config.js
@@ -42,9 +42,9 @@ const moduleRules = [
                 loader: "builtin:swc-loader",
                 /** @type {import('@rspack/core').SwcLoaderOptions} */
                 options: {
+                    detectSyntax: "auto",
                     jsc: {
                         target: "es2024",
-                        parser: { syntax: "typescript", tsx: true },
                         transform: {
                             react: {
                                 runtime: "automatic",

--- a/gulp/rspack.production.config.js
+++ b/gulp/rspack.production.config.js
@@ -49,9 +49,9 @@ const moduleRules = [
                 loader: "builtin:swc-loader",
                 /** @type {import('@rspack/core').SwcLoaderOptions} */
                 options: {
+                    detectSyntax: "auto",
                     jsc: {
                         target: "es2024",
-                        parser: { syntax: "typescript", tsx: true },
                         transform: {
                             react: {
                                 runtime: "automatic",

--- a/gulp/rspack.production.config.js
+++ b/gulp/rspack.production.config.js
@@ -51,6 +51,7 @@ const moduleRules = [
                 options: {
                     jsc: {
                         target: "es2024",
+                        parser: { syntax: "typescript", tsx: true },
                         transform: {
                             react: {
                                 runtime: "automatic",

--- a/gulp/rspack.production.config.js
+++ b/gulp/rspack.production.config.js
@@ -88,7 +88,6 @@ export default {
     },
     stats: { optimizationBailout: true },
     optimization: {
-        removeAvailableModules: true,
         minimizer: [
             new rspack.SwcJsMinimizerRspackPlugin({
                 minimizerOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
             "devDependencies": {
                 "@electron/packager": "^18.3.6",
                 "@eslint/js": "^9.24.0",
-                "@rspack/core": "^1.7.2",
+                "@rspack/core": "^2.0.3",
                 "@tsconfig/node-lts": "^22.0.1",
                 "@tsconfig/strictest": "^2.0.5",
                 "@types/gulp": "^4.0.9",
@@ -826,21 +826,21 @@
             }
         },
         "node_modules/@emnapi/core": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-            "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/wasi-threads": "1.1.0",
+                "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
             }
         },
         "node_modules/@emnapi/runtime": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-            "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+            "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -849,9 +849,9 @@
             }
         },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-            "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+            "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
             "dev": true,
             "license": "MIT",
             "optional": true,
@@ -1226,65 +1226,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@module-federation/error-codes": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
-            "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@module-federation/runtime": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
-            "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@module-federation/error-codes": "0.22.0",
-                "@module-federation/runtime-core": "0.22.0",
-                "@module-federation/sdk": "0.22.0"
-            }
-        },
-        "node_modules/@module-federation/runtime-core": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
-            "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@module-federation/error-codes": "0.22.0",
-                "@module-federation/sdk": "0.22.0"
-            }
-        },
-        "node_modules/@module-federation/runtime-tools": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
-            "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@module-federation/runtime": "0.22.0",
-                "@module-federation/webpack-bundler-runtime": "0.22.0"
-            }
-        },
-        "node_modules/@module-federation/sdk": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
-            "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@module-federation/webpack-bundler-runtime": {
-            "version": "0.22.0",
-            "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
-            "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@module-federation/runtime": "0.22.0",
-                "@module-federation/sdk": "0.22.0"
-            }
-        },
         "node_modules/@msgpack/msgpack": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.2.tgz",
@@ -1295,16 +1236,22 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
-            "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.5.0",
-                "@emnapi/runtime": "^1.5.0",
                 "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -1670,28 +1617,28 @@
             }
         },
         "node_modules/@rspack/binding": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.2.tgz",
-            "integrity": "sha512-bVssRQ39TgGA2RxKEbhUBKYRHln9sbBi0motHmqSU53aMnIkiLXjcj7tZC5dK7Okl2SrHM5KCYK9eG4UodDfdA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-2.0.3.tgz",
+            "integrity": "sha512-4exVNhGhW5RFHjK87XeTKbkA/qAgI5NHJlT1jNqiJv0gcUXLqTOEU3w7f8+f9zUo4JMFvPc0c9veOi4M19YYTg==",
             "dev": true,
             "license": "MIT",
             "optionalDependencies": {
-                "@rspack/binding-darwin-arm64": "1.7.2",
-                "@rspack/binding-darwin-x64": "1.7.2",
-                "@rspack/binding-linux-arm64-gnu": "1.7.2",
-                "@rspack/binding-linux-arm64-musl": "1.7.2",
-                "@rspack/binding-linux-x64-gnu": "1.7.2",
-                "@rspack/binding-linux-x64-musl": "1.7.2",
-                "@rspack/binding-wasm32-wasi": "1.7.2",
-                "@rspack/binding-win32-arm64-msvc": "1.7.2",
-                "@rspack/binding-win32-ia32-msvc": "1.7.2",
-                "@rspack/binding-win32-x64-msvc": "1.7.2"
+                "@rspack/binding-darwin-arm64": "2.0.3",
+                "@rspack/binding-darwin-x64": "2.0.3",
+                "@rspack/binding-linux-arm64-gnu": "2.0.3",
+                "@rspack/binding-linux-arm64-musl": "2.0.3",
+                "@rspack/binding-linux-x64-gnu": "2.0.3",
+                "@rspack/binding-linux-x64-musl": "2.0.3",
+                "@rspack/binding-wasm32-wasi": "2.0.3",
+                "@rspack/binding-win32-arm64-msvc": "2.0.3",
+                "@rspack/binding-win32-ia32-msvc": "2.0.3",
+                "@rspack/binding-win32-x64-msvc": "2.0.3"
             }
         },
         "node_modules/@rspack/binding-darwin-arm64": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.2.tgz",
-            "integrity": "sha512-EsmfzNZnuEhVPMX5jWATCHT2UCCBh6iqq448xUMmASDiKVbIOhUTN1ONTV+aMERYl7BgMNJn0iTis6ot2GWKIg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-2.0.3.tgz",
+            "integrity": "sha512-4UyCjLJwU/WxR6K1/gG4u3+jUsoaRHJ5rNu9fto/UbvrItwdlVNULChAApqZFw6mcSetMddSjSICeuj5pSB6sA==",
             "cpu": [
                 "arm64"
             ],
@@ -1703,9 +1650,9 @@
             ]
         },
         "node_modules/@rspack/binding-darwin-x64": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.2.tgz",
-            "integrity": "sha512-lQLq0eNzFDzR31XD0H5oTG0y8cBoNF9hJ2gt1GgqMlYvaY+pMEeh7s4rTX1/M0c4gHpLudp86SsDuDJ53BwnaQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-2.0.3.tgz",
+            "integrity": "sha512-K3evrbTgZNa8emEqk+AjDtbuoXZp5tPZz3pcEgETxuu3KanW8Zu+Fb+TUp1DEUcL0xOmHPPox8H2cZ3pF4Zmug==",
             "cpu": [
                 "x64"
             ],
@@ -1717,13 +1664,16 @@
             ]
         },
         "node_modules/@rspack/binding-linux-arm64-gnu": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.2.tgz",
-            "integrity": "sha512-rtrsygVbDYw55ukdIk3NEwNQWkUemfRgeNOUvZ0k/6p7eP16020VPDvIqvcmyPtBhwFmz5vfo57GnBLisjM/kw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-2.0.3.tgz",
+            "integrity": "sha512-aPLDaaTtX1wqjLYAIHc2MGDQZtv1Hbjx47oaaefbWz5GbAnSA4P8jdYIeeGRyrqvQ0WqJXIWXgT0d/iXtes00A==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1731,13 +1681,16 @@
             ]
         },
         "node_modules/@rspack/binding-linux-arm64-musl": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.2.tgz",
-            "integrity": "sha512-zhh6ycumTHI7V/VOOT6DolvBe5RFG+Np/e5hhlhjEFtskraO9rkWg8knE9Ssu6a6Qdj4nGscqOj9ENNpc6gb+A==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-2.0.3.tgz",
+            "integrity": "sha512-0WulUQPop6vmSDfrTxghmVlm+6crU8/XqD2f0dOWbEniZVuDZJ5/Y/cBqTRyk3rjl0vrmUv3lc87/t7UgQJQSw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1745,13 +1698,16 @@
             ]
         },
         "node_modules/@rspack/binding-linux-x64-gnu": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.2.tgz",
-            "integrity": "sha512-ON9hy6OTpBOmmFp/51RPa0r9bDbZ3wTTubT54V+yhHuB+eSrlXQIOQScUGCGoGgqp6sLTwKjv2yy7YLyzd1gCA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-2.0.3.tgz",
+            "integrity": "sha512-fAhiMuV5omT53YMft+f3Y9euAFgspuyBAk9ZpeW2buL2TkuUMwP07adhhvQfKdQ5gpELfzmjQaRDGqaIT8UWiA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1759,13 +1715,16 @@
             ]
         },
         "node_modules/@rspack/binding-linux-x64-musl": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.2.tgz",
-            "integrity": "sha512-+2nnjwaSOStgLKtY5O7I3yfkwTkhiJLQ35CwQqWKRw+g1E4OFIKpXBfl34JDtrF/2DeS7sVVyLeuC25+43n9/A==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-2.0.3.tgz",
+            "integrity": "sha512-0kcuFoZ8vy2iNWoISFOZt+/Ujo7LRLrzE7h07AV5r+oN/mv+/v14Sd/8NUtDIScCkrYOszYq/QS31e6t0UrVfw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1773,9 +1732,9 @@
             ]
         },
         "node_modules/@rspack/binding-wasm32-wasi": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.2.tgz",
-            "integrity": "sha512-TU/aLBpm9CTR/RTLF27WlvBKGyju6gpiNTRd3XRbX2JfY3UBNUQN/Ev+gQMVeOj55y9Fruzou42/w9ncTKA0Dw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-2.0.3.tgz",
+            "integrity": "sha512-x2fsw7GzNZEnw444ikj4/b8kVjM0Y0TllxmizHpYZ9gmaQrOk5OXo9RQdz+l4zzoGors0l2IZP5Cc4GJNCaSoQ==",
             "cpu": [
                 "wasm32"
             ],
@@ -1783,13 +1742,15 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "1.0.7"
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "1.1.4"
             }
         },
         "node_modules/@rspack/binding-win32-arm64-msvc": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.2.tgz",
-            "integrity": "sha512-RReQN3AUu46XUZnOy5L/vSj5J+tcl/bzSnGQ2KetZ7dUOjGCC6c0Ki3EiklVM5OC1Agytz0Rz7cJqHJ+HaQbsA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-2.0.3.tgz",
+            "integrity": "sha512-jqlxuVPdrgMuwj/HEjSkC/jmhl4fAuKyob36zJXq2uAusn2FRJ4kClGe1fLFpfxRXFVQAWwlAOwLJg8T0suuaA==",
             "cpu": [
                 "arm64"
             ],
@@ -1801,9 +1762,9 @@
             ]
         },
         "node_modules/@rspack/binding-win32-ia32-msvc": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.2.tgz",
-            "integrity": "sha512-EytrfT2sfUCnRMtXfSNv7AR65DWuY3dX/Bsn1TTin7CC6+RFEAP9nzHtCMISvFPp+c5bveok0/eY8j/f4LZ/Gg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-2.0.3.tgz",
+            "integrity": "sha512-QM4JEuyk5QaZ5gnvnAIaCwVQzCkrD2E4Sud77kx/MVGDsRkcOlMx3blMC5QNHPDamRmWGk+7314YOQvRhKuWyg==",
             "cpu": [
                 "ia32"
             ],
@@ -1815,9 +1776,9 @@
             ]
         },
         "node_modules/@rspack/binding-win32-x64-msvc": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.2.tgz",
-            "integrity": "sha512-zLFt6cr55fjbIy6HT1xS2yLVmtvRjyZ0TbcRum7Ipp+s23gyGHVYNRuDMj34AHnhbCcX/XrxDTzCc4ba6xtYTw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-2.0.3.tgz",
+            "integrity": "sha512-vSQNnAy0wswG6AfNRuArTHQBiXOXl+A9ddQxBFup4PMHUzXxKtsBLQzw7BgFC0EgrPeHbt+30j7sXVZKYukj4A==",
             "cpu": [
                 "x64"
             ],
@@ -1829,34 +1790,29 @@
             ]
         },
         "node_modules/@rspack/core": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.2.tgz",
-            "integrity": "sha512-Pm06phSQqbthbzl92KdnbXmwcnYRv3Ef86uE6hoADqVjsmt2WvJwNjpqgs0S6n+s9UL6QzxqaaAaKg5qeBT+3g==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@rspack/core/-/core-2.0.3.tgz",
+            "integrity": "sha512-2ufO/8FHIA/lX6UOgSsKPhpDvHr0sh9lYq/n/LsIZsTwu3973BGbu2fg1Akvuu3rEnskPqXjsqH2EPBzEA42uA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@module-federation/runtime-tools": "0.22.0",
-                "@rspack/binding": "1.7.2",
-                "@rspack/lite-tapable": "1.1.0"
+                "@rspack/binding": "2.0.3"
             },
             "engines": {
-                "node": ">=18.12.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "peerDependencies": {
+                "@module-federation/runtime-tools": "^0.24.1 || ^2.0.0",
                 "@swc/helpers": ">=0.5.1"
             },
             "peerDependenciesMeta": {
+                "@module-federation/runtime-tools": {
+                    "optional": true
+                },
                 "@swc/helpers": {
                     "optional": true
                 }
             }
-        },
-        "node_modules/@rspack/lite-tapable": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
-            "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@sindresorhus/is": {
             "version": "6.3.1",
@@ -1893,9 +1849,9 @@
             "license": "MIT"
         },
         "node_modules/@tybys/wasm-util": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "version": "0.10.2",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+            "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
             "dev": true,
             "license": "MIT",
             "optional": true,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "devDependencies": {
         "@electron/packager": "^18.3.6",
         "@eslint/js": "^9.24.0",
-        "@rspack/core": "^1.7.2",
+        "@rspack/core": "^2.0.3",
         "@tsconfig/node-lts": "^22.0.1",
         "@tsconfig/strictest": "^2.0.5",
         "@types/gulp": "^4.0.9",


### PR DESCRIPTION
This PR fixes another regression from the transition to SWC. Before this fix, .jsx files were not parsed correctly by SWC and failed to build.

Although the new config tells SWC to parse everything as TSX for simplicity, I have not found it to harm build times at all.