### PR TITLE
Fix bug that causes crash/white screen on Windows, add checks

### DIFF
--- a/src/js/mods/modloader.ts
+++ b/src/js/mods/modloader.ts
@@ -103,7 +103,7 @@ export class ModLoader {
             regExp: /\.[jt]sx?$/,
             // NOTE: Worker scripts are executed if not explicitly excluded, which causes
             // infinite recursion!
-            exclude: /\/webworkers\/|\.d\.ts$|jsx-dev-runtime\.ts$/,
+            exclude: /\/webworkers\/|\\webworkers\\|\.d\.ts$|jsx-dev-runtime\.ts$/,
         });
 
         Array.from(modules.keys()).forEach(key => {

--- a/src/js/webworkers/background_animation_frame_emittter.js
+++ b/src/js/webworkers/background_animation_frame_emittter.js
@@ -1,5 +1,9 @@
 /// <reference lib="WebWorker" />
 
+if (!(typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope)) {
+    throw new Error("webworkers should never be run on the main thread!");
+}
+
 // We clamp high deltas so 30 fps is fairly ok
 const bgFps = 30;
 const desiredMsDelay = 1000 / bgFps;

--- a/src/js/webworkers/compression.ts
+++ b/src/js/webworkers/compression.ts
@@ -1,5 +1,9 @@
 /// <reference lib="WebWorker" />
 
+if (!(typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope)) {
+    throw new Error("webworkers should never be run on the main thread!");
+}
+
 import { encode } from "@msgpack/msgpack";
 
 async function compress(data: unknown): Promise<Uint8Array> {

--- a/src/js/webworkers/decompression.ts
+++ b/src/js/webworkers/decompression.ts
@@ -1,5 +1,9 @@
 /// <reference lib="WebWorker" />
 
+if (!(typeof WorkerGlobalScope !== "undefined" && self instanceof WorkerGlobalScope)) {
+    throw new Error("webworkers should never be run on the main thread!");
+}
+
 import { decodeAsync } from "@msgpack/msgpack";
 
 async function decompress(data: Uint8Array): Promise<unknown> {


### PR DESCRIPTION
This PR fixes a bug caused by a difference in behavior of `import.meta.webpackContext` between Rspack and Webpack. 

It also add checks to make sure that webworkers are not executed on the main thread (which was part of the cause of the crash/white screen).