### PR TITLE
Remove most `typehints` blocks

### DIFF
--- a/src/js/core/background_resources_loader.js
+++ b/src/js/core/background_resources_loader.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "../application";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ */
 
 import { initSpriteCache } from "../game/meta_building_registry";
 import { MUSIC, SOUNDS } from "../platform/sound";

--- a/src/js/core/globals.js
+++ b/src/js/core/globals.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "../application";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ */
 
 /**
  * Used for the bug reporter, and the click detector which both have no handles to this.

--- a/src/js/core/read_write_proxy.js
+++ b/src/js/core/read_write_proxy.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Storage } from "@/platform/storage";
-/* typehints:end */
+/**
+ * @import { Storage } from "@/platform/storage"
+ */
 
 import { FsError } from "@/platform/fs_error";
 import { ExplainedResult } from "./explained_result";

--- a/src/js/core/state_manager.js
+++ b/src/js/core/state_manager.js
@@ -1,6 +1,6 @@
-/* typehints:start*/
-import { Application } from "../application";
-/* typehints:end*/
+/**
+ * @import { Application } from "../application"
+ */
 
 import { MOD_SIGNALS } from "../mods/mod_signals";
 import { GameState } from "./game_state";

--- a/src/js/game/building_codes.js
+++ b/src/js/game/building_codes.js
@@ -1,8 +1,8 @@
-/* typehints:start */
-import { MetaBuilding } from "./meta_building";
-import { AtlasSprite } from "../core/sprites";
-import { Vector } from "../core/vector";
-/* typehints:end */
+/**
+ * @import { MetaBuilding } from "./meta_building"
+ * @import { AtlasSprite } from "../core/sprites"
+ * @import { Vector } from "../core/vector"
+ */
 
 import { gMetaBuildingRegistry } from "../core/global_registries";
 

--- a/src/js/game/buildings/block.js
+++ b/src/js/game/buildings/block.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Entity } from "../entity";
-/* typehints:end */
+/**
+ * @import { Entity } from "../entity"
+ */
 
 import { defaultBuildingVariant, MetaBuilding } from "../meta_building";
 

--- a/src/js/game/buildings/constant_producer.js
+++ b/src/js/game/buildings/constant_producer.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Entity } from "../entity";
-/* typehints:end */
+/**
+ * @import { Entity } from "../entity"
+ */
 
 import { enumDirection, Vector } from "../../core/vector";
 import { ConstantSignalComponent } from "../components/constant_signal";

--- a/src/js/game/buildings/goal_acceptor.js
+++ b/src/js/game/buildings/goal_acceptor.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Entity } from "../entity";
-/* typehints:end */
+/**
+ * @import { Entity } from "../entity"
+ */
 
 import { enumDirection, Vector } from "../../core/vector";
 import { GoalAcceptorComponent } from "../components/goal_acceptor";

--- a/src/js/game/core.js
+++ b/src/js/game/core.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "../application";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ */
 import { BufferMaintainer } from "../core/buffer_maintainer";
 import { getBufferStats } from "../core/buffer_utils";
 import { globalConfig } from "../core/config";

--- a/src/js/game/entity.js
+++ b/src/js/game/entity.js
@@ -1,7 +1,7 @@
-/* typehints:start */
-import { DrawParameters } from "../core/draw_parameters";
-import { Component } from "./component";
-/* typehints:end */
+/**
+ * @import { DrawParameters } from "../core/draw_parameters"
+ * @import { Component } from "./component"
+ */
 
 import { GameRoot } from "./root";
 import { globalConfig } from "../core/config";

--- a/src/js/game/game_loading_overlay.js
+++ b/src/js/game/game_loading_overlay.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "../application";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ */
 
 import { randomChoice } from "../core/utils";
 import { T } from "../translations";

--- a/src/js/game/game_mode.js
+++ b/src/js/game/game_mode.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { GameRoot } from "./root";
-/* typehints:end */
+/**
+ * @import { GameRoot } from "./root"
+ */
 
 import { gGameModeRegistry } from "../core/global_registries";
 import { Rectangle } from "../core/rectangle";

--- a/src/js/game/game_system.js
+++ b/src/js/game/game_system.js
@@ -1,7 +1,7 @@
-/* typehints:start */
-import { GameRoot } from "./root";
-import { DrawParameters } from "../core/draw_parameters";
-/* typehints:end */
+/**
+ * @import { GameRoot } from "./root"
+ * @import { DrawParameters } from "../core/draw_parameters"
+ */
 
 /**
  * A game system processes all entities which match a given schema, usually a list of

--- a/src/js/game/game_system_manager.js
+++ b/src/js/game/game_system_manager.js
@@ -1,7 +1,7 @@
-/* typehints:start */
-import { GameSystem } from "./game_system";
-import { GameRoot } from "./root";
-/* typehints:end */
+/**
+ * @import { GameSystem } from "./game_system"
+ * @import { GameRoot } from "./root"
+ */
 
 import { Logger } from "../core/logging";
 import { BeltSystem } from "./systems/belt";

--- a/src/js/game/game_system_with_filter.js
+++ b/src/js/game/game_system_with_filter.js
@@ -1,7 +1,7 @@
-/* typehints:start */
-import { Component } from "./component";
-import { Entity } from "./entity";
-/* typehints:end */
+/**
+ * @import { Component } from "./component"
+ * @import { Entity } from "./entity"
+ */
 
 import { GameRoot } from "./root";
 import { GameSystem } from "./game_system";

--- a/src/js/game/game_time.js
+++ b/src/js/game/game_time.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { GameRoot } from "./root";
-/* typehints:end */
+/**
+ * @import { GameRoot } from "./root"
+ */
 
 import { globalConfig } from "../core/config";
 import { BasicSerializableObject, types } from "../savegame/serialization";

--- a/src/js/game/hud/base_hud_part.js
+++ b/src/js/game/hud/base_hud_part.js
@@ -1,7 +1,7 @@
-/* typehints:start */
-import { DrawParameters } from "../../core/draw_parameters";
-import { GameRoot } from "../root";
-/* typehints:end */
+/**
+ * @import { DrawParameters } from "../../core/draw_parameters"
+ * @import { GameRoot } from "../root"
+ */
 
 import { ClickDetector } from "../../core/click_detector";
 

--- a/src/js/game/hud/hud.js
+++ b/src/js/game/hud/hud.js
@@ -57,12 +57,6 @@ export class GameHUD {
             settingsMenu: new HUDSettingsMenu(this.root),
             debugInfo: new HUDDebugInfo(this.root),
             dialogs: new HUDModalDialogs(this.root),
-
-            // Typing hints
-            /* typehints:start */
-            /** @type {HUDChangesDebugger} */
-            changesDebugger: null,
-            /* typehints:end */
         };
 
         if (G_IS_DEV) {

--- a/src/js/game/hud/parts/mass_selector.js
+++ b/src/js/game/hud/parts/mass_selector.js
@@ -12,10 +12,6 @@ import { THEME } from "../../theme";
 import { enumHubGoalRewards } from "../../tutorial_goals";
 import { BaseHUDPart } from "../base_hud_part";
 
-/* typehints:start */
-// @ts-ignore
-/* typehints:end */
-
 const logger = new Logger("hud/mass_selector");
 
 export class HUDMassSelector extends BaseHUDPart {

--- a/src/js/game/hud/parts/modal_dialogs.js
+++ b/src/js/game/hud/parts/modal_dialogs.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "../../../application";
-/* typehints:end */
+/**
+ * @import { Application } from "../../../application"
+ */
 
 import { SOUNDS } from "../../../platform/sound";
 import { DynamicDomAttach } from "../dynamic_dom_attach";

--- a/src/js/game/hud/parts/next_puzzle.js
+++ b/src/js/game/hud/parts/next_puzzle.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { PuzzlePlayGameMode } from "../../modes/puzzle_play";
-/* typehints:end */
+/**
+ * @import { PuzzlePlayGameMode } from "../../modes/puzzle_play"
+ */
 
 import { makeDiv } from "../../../core/utils";
 import { T } from "../../../translations";

--- a/src/js/game/hud/parts/puzzle_complete_notification.js
+++ b/src/js/game/hud/parts/puzzle_complete_notification.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { PuzzlePlayGameMode } from "../../modes/puzzle_play";
-/* typehints:end */
+/**
+ * @import { PuzzlePlayGameMode } from "../../modes/puzzle_play"
+ */
 
 import { InputReceiver } from "../../../core/input_receiver";
 import { makeDiv } from "../../../core/utils";

--- a/src/js/game/hud/parts/puzzle_play_metadata.js
+++ b/src/js/game/hud/parts/puzzle_play_metadata.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { PuzzlePlayGameMode } from "../../modes/puzzle_play";
-/* typehints:end */
+/**
+ * @import { PuzzlePlayGameMode } from "../../modes/puzzle_play"
+ */
 
 import { formatBigNumberFull, formatSeconds, makeDiv } from "../../../core/utils";
 import { T } from "../../../translations";

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -1,8 +1,8 @@
-/* typehints:start */
-import { Application } from "../application";
-import { InputReceiver } from "../core/input_receiver";
-import { GameRoot } from "./root";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ * @import { InputReceiver } from "../core/input_receiver"
+ * @import { GameRoot } from "./root"
+ */
 
 import { getStringForKeyCode, KEYCODES, keyToKeyCode } from "@/core/keycodes";
 import { IS_MOBILE } from "../core/config";

--- a/src/js/game/modes/puzzle.js
+++ b/src/js/game/modes/puzzle.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { GameRoot } from "../root";
-/* typehints:end */
+/**
+ * @import { GameRoot } from "../root"
+ */
 
 import { Rectangle } from "../../core/rectangle";
 import { types } from "../../savegame/serialization";

--- a/src/js/game/modes/puzzle_edit.js
+++ b/src/js/game/modes/puzzle_edit.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { GameRoot } from "../root";
-/* typehints:end */
+/**
+ * @import { GameRoot } from "../root"
+ */
 
 import { enumGameModeIds } from "../game_mode";
 import { PuzzleGameMode } from "./puzzle";

--- a/src/js/game/modes/puzzle_play.js
+++ b/src/js/game/modes/puzzle_play.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { GameRoot } from "../root";
-/* typehints:end */
+/**
+ * @import { GameRoot } from "../root"
+ */
 
 import { enumGameModeIds } from "../game_mode";
 import { PuzzleGameMode } from "./puzzle";

--- a/src/js/game/modes/regular.js
+++ b/src/js/game/modes/regular.js
@@ -1,7 +1,7 @@
-/* typehints:start */
-import { MetaBuilding } from "../meta_building";
-import { GameRoot } from "../root";
-/* typehints:end */
+/**
+ * @import { MetaBuilding } from "../meta_building"
+ * @import { GameRoot } from "../root"
+ */
 
 import { IS_MOBILE } from "../../core/config";
 import { findNiceIntegerValue } from "../../core/utils";

--- a/src/js/game/root.js
+++ b/src/js/game/root.js
@@ -3,31 +3,31 @@ import { RandomNumberGenerator } from "../core/rng";
 import { Signal } from "../core/signal";
 
 // Type hints
-/* typehints:start */
-import { Application } from "../application";
-import { BufferMaintainer } from "../core/buffer_maintainer";
-import { Vector } from "../core/vector";
-import { Savegame } from "../savegame/savegame";
-import { InGameState } from "../states/ingame";
-import { AutomaticSave } from "./automatic_save";
-import { BaseItem } from "./base_item";
-import { Camera } from "./camera";
-import { DynamicTickrate } from "./dynamic_tickrate";
-import { Entity } from "./entity";
-import { EntityManager } from "./entity_manager";
-import { GameMode } from "./game_mode";
-import { GameSystemManager } from "./game_system_manager";
-import { GameTime } from "./game_time";
-import { HubGoals } from "./hub_goals";
-import { GameHUD } from "./hud/hud";
-import { KeyActionMapper } from "./key_action_mapper";
-import { GameLogic } from "./logic";
-import { MapView } from "./map_view";
-import { ProductionAnalytics } from "./production_analytics";
-import { ShapeDefinition } from "./shape_definition";
-import { ShapeDefinitionManager } from "./shape_definition_manager";
-import { SoundProxy } from "./sound_proxy";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ * @import { BufferMaintainer } from "../core/buffer_maintainer"
+ * @import { Vector } from "../core/vector"
+ * @import { Savegame } from "../savegame/savegame"
+ * @import { InGameState } from "../states/ingame"
+ * @import { AutomaticSave } from "./automatic_save"
+ * @import { BaseItem } from "./base_item"
+ * @import { Camera } from "./camera"
+ * @import { DynamicTickrate } from "./dynamic_tickrate"
+ * @import { Entity } from "./entity"
+ * @import { EntityManager } from "./entity_manager"
+ * @import { GameMode } from "./game_mode"
+ * @import { GameSystemManager } from "./game_system_manager"
+ * @import { GameTime } from "./game_time"
+ * @import { HubGoals } from "./hub_goals"
+ * @import { GameHUD } from "./hud/hud"
+ * @import { KeyActionMapper } from "./key_action_mapper"
+ * @import { GameLogic } from "./logic"
+ * @import { MapView } from "./map_view"
+ * @import { ProductionAnalytics } from "./production_analytics"
+ * @import { ShapeDefinition } from "./shape_definition"
+ * @import { ShapeDefinitionManager } from "./shape_definition_manager"
+ * @import { SoundProxy } from "./sound_proxy"
+ */
 
 const logger = new Logger("game/root");
 

--- a/src/js/game/sound_proxy.js
+++ b/src/js/game/sound_proxy.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { GameRoot } from "./root";
-/* typehints:end */
+/**
+ * @import { GameRoot } from "./root"
+ */
 
 import { SOUNDS } from "../platform/sound";
 

--- a/src/js/game/systems/zone.js
+++ b/src/js/game/systems/zone.js
@@ -1,8 +1,8 @@
-/* typehints:start */
-import { DrawParameters } from "../../core/draw_parameters";
-import { MapChunkView } from "../map_chunk_view";
-import { GameRoot } from "../root";
-/* typehints:end */
+/**
+ * @import { DrawParameters } from "../../core/draw_parameters"
+ * @import { MapChunkView } from "../map_chunk_view"
+ * @import { GameRoot } from "../root"
+ */
 
 import { globalConfig } from "../../core/config";
 import { STOP_PROPAGATION } from "../../core/signal";

--- a/src/js/mods/mod_interface.js
+++ b/src/js/mods/mod_interface.js
@@ -1,9 +1,9 @@
-/* typehints:start */
-import { Component } from "../game/component";
-import { GameSystem } from "../game/game_system";
-import { MetaBuilding } from "../game/meta_building";
-import { ModLoader } from "./modloader";
-/* typehints:end */
+/**
+ * @import { Component } from "../game/component"
+ * @import { GameSystem } from "../game/game_system"
+ * @import { MetaBuilding } from "../game/meta_building"
+ * @import { ModLoader } from "./modloader"
+ */
 
 import { gComponentRegistry, gItemRegistry, gMetaBuildingRegistry } from "../core/global_registries";
 import { Loader } from "../core/loader";

--- a/src/js/platform/api.js
+++ b/src/js/platform/api.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "../application";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ */
 
 import { Logger } from "../core/logging";
 import { DialogWithForm } from "../core/modal_dialog_elements";

--- a/src/js/platform/sound.js
+++ b/src/js/platform/sound.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "../application";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ */
 
 import { Howl, Howler } from "howler";
 import { globalConfig } from "../core/config";

--- a/src/js/platform/wrapper.js
+++ b/src/js/platform/wrapper.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "../application";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ */
 
 import { IS_MOBILE } from "../core/config";
 import { Logger } from "../core/logging";

--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "../application";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ */
 
 import { ExplainedResult } from "../core/explained_result";
 import { Logger } from "../core/logging";

--- a/src/js/profile/setting_types.js
+++ b/src/js/profile/setting_types.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "../application";
-/* typehints:end */
+/**
+ * @import { Application } from "../application"
+ */
 
 import { Logger } from "../core/logging";
 import { T } from "../translations";

--- a/src/js/savegame/puzzle_serializer.js
+++ b/src/js/savegame/puzzle_serializer.js
@@ -1,7 +1,7 @@
-/* typehints:start */
-import { GameRoot } from "../game/root";
-import { PuzzleGameMode } from "../game/modes/puzzle";
-/* typehints:end */
+/**
+ * @import { GameRoot } from "../game/root"
+ * @import { PuzzleGameMode } from "../game/modes/puzzle"
+ */
 import { StaticMapEntityComponent } from "../game/components/static_map_entity";
 import { ShapeItem } from "../game/items/shape_item";
 import { Vector } from "../core/vector";

--- a/src/js/savegame/savegame_manager.js
+++ b/src/js/savegame/savegame_manager.js
@@ -1,6 +1,6 @@
-/* typehints:start */
-import { Application } from "@/application";
-/* typehints:end */
+/**
+ * @import { Application } from "@/application"
+ */
 
 import { globalConfig } from "../core/config";
 import { ExplainedResult } from "../core/explained_result";

--- a/src/js/savegame/serialization_data_types.js
+++ b/src/js/savegame/serialization_data_types.js
@@ -1,7 +1,7 @@
-/* typehints:start */
-import { GameRoot } from "../game/root";
-import { BasicSerializableObject } from "./serialization";
-/* typehints:end */
+/**
+ * @import { GameRoot } from "../game/root"
+ * @import { BasicSerializableObject } from "./serialization"
+ */
 
 import { round4Digits } from "../core/utils";
 import { Vector } from "../core/vector";


### PR DESCRIPTION
This PR replaces imports inside `typehints` blocks with `@import` in a JSDoc comment. A couple other useless `typehints` blocks were removed. 

There are a couple remaining `typehints` blocks where the best solution would be to rewrite the file in TypeScript.